### PR TITLE
Fix RecordLinux startStream build error

### DIFF
--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,14 +7,14 @@ import Foundation
 
 import geolocator_apple
 import path_provider_foundation
-import record_darwin
+import record_macos
 import speech_to_text
 import sqflite_darwin
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   GeolocatorPlugin.register(with: registry.registrar(forPlugin: "GeolocatorPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
-  RecordPlugin.register(with: registry.registrar(forPlugin: "RecordPlugin"))
+  RecordMacOsPlugin.register(with: registry.registrar(forPlugin: "RecordMacOsPlugin"))
   SpeechToTextPlugin.register(with: registry.registrar(forPlugin: "SpeechToTextPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -364,10 +364,10 @@ packages:
     dependency: "direct main"
     description:
       name: record
-      sha256: "2e3d56d196abcd69f1046339b75e5f3855b2406fc087e5991f6703f188aa03a6"
+      sha256: "9dbc6ff3e784612f90a9b001373c45ff76b7a08abd2bd9fdf72c242320c8911c"
       url: "https://pub.dev"
     source: hosted
-    version: "5.2.1"
+    version: "6.1.1"
   record_android:
     dependency: transitive
     description:
@@ -376,22 +376,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
-  record_darwin:
+  record_ios:
     dependency: transitive
     description:
-      name: record_darwin
-      sha256: e487eccb19d82a9a39cd0126945cfc47b9986e0df211734e2788c95e3f63c82c
+      name: record_ios
+      sha256: "13e241ed9cbc220534a40ae6b66222e21288db364d96dd66fb762ebd3cb77c71"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.2"
+    version: "1.1.2"
   record_linux:
     dependency: transitive
     description:
       name: record_linux
-      sha256: "74d41a9ebb1eb498a38e9a813dd524e8f0b4fdd627270bda9756f437b110a3e3"
+      sha256: "235b1f1fb84e810f8149cc0c2c731d7d697f8d1c333b32cb820c449bf7bb72d8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "1.2.1"
+  record_macos:
+    dependency: transitive
+    description:
+      name: record_macos
+      sha256: "2849068bb59072f300ad63ed146e543d66afaef8263edba4de4834fc7c8d4d35"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   record_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   cupertino_icons: ^1.0.8
   
   # Audio recording and speech recognition
-  record: ^5.0.5
+  record: ^6.1.1
   speech_to_text: ^7.0.0
   permission_handler: ^11.0.1
   path_provider: ^2.1.1


### PR DESCRIPTION
## Summary
- Upgraded `record` package from 5.2.1 to 6.1.1
- This resolves the missing `startStream` method implementation error in `record_linux` 
- The update brings in `record_linux` 1.2.1 which includes the required method

## Problem
The app build was failing with:
```
Error: The non-abstract class 'RecordLinux' is missing implementations for these members:
- RecordMethodChannelPlatformInterface.startStream
```

## Solution
Updated the `record` dependency to a newer version that includes a compatible `record_linux` package with the `startStream` method implementation.

## Test plan
- [x] Run `flutter pub get` to update dependencies
- [x] Build the app with `flutter build apk --debug`
- [x] Verify build completes successfully without errors

🤖 Generated with [Claude Code](https://claude.ai/code)